### PR TITLE
[docs]: created code & contributing docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders of this open-source project pledge 
+to make participation in our community and contribution to our project an 
+inclusive experience for everyone, regardless of age, body size, visible or 
+invisible disability, ethnicity, gender identity, and expression, sexual identity 
+and orientation, level of experience, education, socio-economic status, 
+nationality, personal appearance, race, caste, color, or religion.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people.
+* Being respectful of differing opinions, viewpoints, and experiences.
+* Giving and gracefully accepting constructive feedback.
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience.
+* Focusing on what is best not just for us as individuals, but for the overall
+  community.
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+hello.tas@lambdatest.com
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to Test-at-scale-scripts
+
+Thank you for your interest in Test-at-scale-scripts, the scripting repository for Test-at-scale, and for taking the time to contribute to this project. If you feel insecure about how to start contributing, feel free to ask us on our [Discord Server](https://discord.gg/Wyf8srhf6K) in the #contribute channel.
+
+## **Code of conduct**
+
+Read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+
+
+## **How can I contribute?**
+
+There are many ways in which you can contribute to Test-at-scale.
+
+#### 👥 Join the community
+&emsp;&emsp;Join our [Discord server](https://discord.gg/Wyf8srhf6K), help others use Test-at-scale for their test automation requirements.
+
+
+#### 📝 Improve the documentation
+&emsp;&emsp;Suggest improvements to our documentation using the [Documentation Improvement](https://github.com/LambdaTest/test-at-scale-scripts/issues/new) template. 
+
+ 
+### First-time contributors
+We appreciate first-time contributors and we are happy to assist you in getting started. In case of questions, just [reach out to us!](https://discord.gg/Wyf8srhf6K)
+Look for any issues with the label **good first issue** and start contributing
+
+
+## **Committing code**
+
+The repository contains only one branch.
+
+ * main contains the code that is tested and released. 
+
+Pull requests should be made against the <span style="color:grey">main</span> branch that contains all of the new features and fixes that are under testing and ready to go out in the next release.
+
+
+#### **Commit & Create Pull Requests** 
+
+ 1. Please make sure there is an issue associated with the work that you're doing. If it doesn’t exist, [create an issue](https://github.com/LambdaTest/test-at-scale-scripts/issues).
+ 2. Squash your commits and refer to the issue using `Fix #<issue-no>` in the commit message, at the start.
+ 3. Rebase `dev` with your branch and push your changes.
+ 4. Once you are confident in your code changes, create a pull request in your fork to the `dev` branch in the LambdaTest/test-at-scale base repository.
+ 5. Link the issue of the base repository in your Pull request description. [Guide](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+ 6. Fill out the **Pull Request Template** completely within the body of the PR. If you feel some areas are not relevant add `N/A` but don’t delete those sections.
+
+
+####  **Commit messages**
+
+- The first line should be a summary of the changes, not exceeding 50
+  characters, followed by an optional body that has more details about the
+  changes. Refer to [this link](https://github.com/erlang/otp/wiki/writing-good-commit-messages)
+  for more information on writing good commit messages.
+
+- Don't add a period/dot (.) at the end of the summary line.


### PR DESCRIPTION
Fixes #12 

- Created the Code of Conduct as well as the Contributing files.
- The contributing file provides a quick summary and can be further updated as the repo expands